### PR TITLE
fix: optimized pydantic schema for the seat's response model

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,10 @@
 from fastapi import FastAPI, HTTPException, Depends
-from schema import UserCreate, UserOut, ShowCreate, ShowOut, SeatCreateBulk, SeatOut, ReservationCreate, ReservationOut
+from schema import UserCreate, UserOut, ShowCreate, ShowOut, SeatCreateBulk, SeatOut, ReservationCreate, ReservationOut, SeatAvailabilityOut
 from models import User, Show, Seat, Reservation
 from database import get_db
 from services import hash_password, normalize_seat_labels, calculate_hold_expiry
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import select, func
-from datetime import datetime, timezone
 import uvicorn
 
 
@@ -180,6 +179,7 @@ def confirm_seat_reservation(reservation_id: int, db=Depends(get_db)):
     db.refresh(reservation)
     return reservation
 
+# cancel reservation endpoint
 @app.post("/reservations/{reservation_id}/release", response_model=ReservationOut)
 def release_seat_reservation(reservation_id: int, db=Depends(get_db)):
     # find if reservation exists
@@ -208,6 +208,14 @@ def release_seat_reservation(reservation_id: int, db=Depends(get_db)):
     db.refresh(reservation)
 
     return reservation
+
+# list seats with status
+@app.get("/shows/{show_id}/availability", response_model=SeatAvailabilityOut)
+def list_seat_availability(show_id: int, db=Depends(get_db)):
+
+
+
+
 
 
 if __name__ == "__main__":

--- a/app/schema.py
+++ b/app/schema.py
@@ -45,7 +45,16 @@ class SeatOut(BaseModel):
     class Config:
         orm_mode = True
 
- 
+class SeatAvailabilityOut(BaseModel):
+    seat_id: str
+    seat_number: str
+    status: Literal["AVAILABLE", "HELD", "RESERVED"]
+    hold_expiry: datetime | None = None
+
+    class Config:
+        orm_mode = True
+
+
 # Reservation Schemas
 class ReservationCreate(BaseModel):
     seat_number: str
@@ -63,3 +72,4 @@ class ReservationOut(BaseModel):
 
     class Config:
         orm_mode = True
+


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added new `SeatAvailabilityOut` schema for seat availability endpoint

- Implemented `/shows/{show_id}/availability` endpoint stub for listing seat status

- Added comment for cancel reservation endpoint

- Removed unused `datetime` import from `main.py`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  schema["SeatAvailabilityOut schema"] --> endpoint["GET /shows/{show_id}/availability"]
  endpoint --> response["Seat status response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.py</strong><dd><code>Add seat availability response schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/schema.py

<ul><li>Added <code>SeatAvailabilityOut</code> schema with seat status fields<br> <li> Included <code>status</code> field with literal types (AVAILABLE, HELD, RESERVED)<br> <li> Added optional <code>hold_expiry</code> field for held seats</ul>


</details>


  </td>
  <td><a href="https://github.com/Caldwell10/Event-Ticketing-API/pull/20/files#diff-18b578955e27aedbd9e05e4b6fa89fe0b3e3bceb1ec27dc626e4fb58bccae686">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add seat availability endpoint and cleanup imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/main.py

<ul><li>Imported new <code>SeatAvailabilityOut</code> schema<br> <li> Added stub for <code>list_seat_availability</code> endpoint<br> <li> Removed unused <code>datetime</code> import<br> <li> Added comment for cancel reservation endpoint</ul>


</details>


  </td>
  <td><a href="https://github.com/Caldwell10/Event-Ticketing-API/pull/20/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

