### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ON reservations(seat_id)
 WHERE status IN ('HELD','CONFIRMED');
 ```
 
-## API (v1)
+## API
 - `POST /users/` → create a user `{ name, phone_number, email, password }`.
 - `POST /shows/` → create a show `{ title, venue, starts_at }`.
 - `POST /shows/{show_id}/seats` → bulk create seats, normalizing labels (`["A1", "A2", " c5 "] → ["A1","A2","C5"]`).


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Remove version number from API section heading

- Simplify documentation by changing "API (v1)" to "API"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md<br/>API v1 heading"] -- "Remove version suffix" --> B["README.md<br/>API heading"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Simplify API section heading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Changed section heading from "## API (v1)" to "## API"<br> <li> Removed version number notation from documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/Caldwell10/Event-Ticketing-API/pull/26/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).