### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,6 @@ A backend system that entails selling event seats with time-boxed holds, race-sa
 - Pytest 
 - Uvicorn
 
-## Data Model (Simplified)
-```
-User(id, name, phone_number, email, password)
-Show(id, title, venue, starts_at)
-Seat(id, show_id -> Show.id, seat_number UNIQUE per show)
-Reservation(
-  id, user_id -> User.id, seat_id -> Seat.id,
-  status ∈ {HELD, CONFIRMED, EXPIRED, CANCELLED},
-  hold_expiry, created_at, updated_at
-)
-
--- Prevent double booking
-CREATE UNIQUE INDEX unique_active_reservation_per_seat
-ON reservations(seat_id)
-WHERE status IN ('HELD','CONFIRMED');
-```
-
 ## API
 - `POST /users/` → create a user `{ name, phone_number, email, password }`.
 - `POST /shows/` → create a show `{ title, venue, starts_at }`.


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Remove outdated data model section from README

- Simplify documentation by eliminating redundant schema details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  README["README.md"]
  README -- "removes Data Model section" --> SIMPLIFIED["Simplified schema removed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Remove data model documentation section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Removed "Data Model (Simplified)" section containing User, Show, Seat, <br>and Reservation entity definitions<br> <li> Deleted database schema documentation including UNIQUE INDEX <br>constraint for preventing double bookings<br> <li> Kept API documentation and dependencies sections intact</ul>


</details>


  </td>
  <td><a href="https://github.com/Caldwell10/Event-Ticketing-API/pull/27/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+0/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).